### PR TITLE
Fix issue with ConfigParser interpolation by disabling

### DIFF
--- a/monitoring/settings.py
+++ b/monitoring/settings.py
@@ -26,7 +26,7 @@ DEBUG = False
 try:
 
     # Read configuration from the file
-    cp = configparser.ConfigParser()
+    cp = configparser.ConfigParser(interpolation=None)
     file_path = os.path.join(BASE_DIR, 'monitoring', 'settings.ini')
     cp.read(file_path)
 


### PR DESCRIPTION
Resolves https://github.com/apel/monitoring/issues/29

Tested by manually applying change to host.