### PR TITLE
Filter all db update queries to last 3 years

### DIFF
--- a/monitoring/publishing/db_update_sqlite.py
+++ b/monitoring/publishing/db_update_sqlite.py
@@ -89,6 +89,7 @@ def refresh_gridsite():
                 Site,
                 max(LatestEndTime) AS LatestPublish
             FROM VSuperSummaries
+            WHERE LatestEndTime > DATE_SUB(NOW(), INTERVAL 3 YEAR)
             GROUP BY 1;
         """
         fetchset = VSuperSummaries.objects.using('grid').raw(sql_query)
@@ -118,7 +119,7 @@ def refresh_cloudsite():
                     SiteName,
                     MAX(UpdateTime) AS latest
                 FROM VAnonCloudRecords
-                WHERE UpdateTime>'2023-01-01'
+                WHERE UpdateTime > DATE_SUB(NOW(), INTERVAL 3 YEAR)
                 GROUP BY SiteName
             )
             AS a
@@ -158,6 +159,7 @@ def refresh_gridsitesync():
                 MAX(LatestEndTime) AS RecordEnd
             FROM VSuperSummaries
             WHERE
+                Year >= YEAR(NOW()) - 3 AND
                 EarliestEndTime>'1900-01-01' AND
                 LatestEndTime>'1900-01-01'
             GROUP BY
@@ -172,6 +174,8 @@ def refresh_gridsitesync():
                 Year,
                 SUM(NumberOfJobs) AS RecordCountInDb
             FROM VSyncRecords
+            WHERE
+                Year >= YEAR(NOW()) - 3
             GROUP BY
                 Site, Year, Month;
         """

--- a/monitoring/publishing/templates/cloudsites.html
+++ b/monitoring/publishing/templates/cloudsites.html
@@ -8,7 +8,7 @@
 </head>
 
 <body>
-  <h2>Sites publishing cloud accounting records from 2018-06-19 onwards</h2>
+  <h2>Sites publishing cloud accounting records in last 3 years</h2>
   <p>Page last updated: {{ last_fetched|date:"Y-m-d H:i:s.u" }}</p>
   <table border="1">
     <tr>


### PR DESCRIPTION
We don't really care about data past this point, so fetching less should improve performance a bit and not overwhelm the interface.

The description on the cloud page is updated to match.

Tested on an EL8 VM.