### PR TITLE
Convert remaining url() to path()

### DIFF
--- a/monitoring/availability/urls.py
+++ b/monitoring/availability/urls.py
@@ -1,7 +1,7 @@
-from django.conf.urls import url
+from django.urls import path
 
 from monitoring.availability import views
 
 urlpatterns = [
-    url(r'^$', views.status, name='availability'),
+    path('', views.status, name='availability'),
 ]


### PR DESCRIPTION
Resolves #57 

url() is deprecating and is directly replaced by re_path(), but the new simpler path() function suits this use case.