### PR TITLE
Revert "Remove unused code introduced in earlier commits"

### DIFF
--- a/monitoring/db_update_sqlite.py
+++ b/monitoring/db_update_sqlite.py
@@ -40,6 +40,9 @@ from monitoring.publishing.models import (
 
 from monitoring.benchmarks.models import (
     BenchmarksBySubmithost,
+    VJobRecords,
+    VSummaries,
+    VNormalisedSummaries,
 )
 
 summaries_dict_standard = {


### PR DESCRIPTION
This reverts commit c054ab7faa254e39a486ad332f67e6b734a5fccb.

These imports are actually needed as they're used as a way to dynamically fetch references from globals().