### PR TITLE
Add iris app to show IRIS cloud and grid accounting records

### DIFF
--- a/monitoring/db_update_sqlite.py
+++ b/monitoring/db_update_sqlite.py
@@ -496,7 +496,7 @@ def refresh_iris_cloud_grid():
             WHERE LatestEndTime > DATE_SUB(NOW(), INTERVAL 1 YEAR)
             GROUP BY 1;
         """
-        fetchset = VSuperSummaries.objects.using('grid').raw(sql_query)
+        fetchset = VSuperSummaries.objects.using('iris_grid').raw(sql_query)
 
         for f in fetchset:
             IrisCloudGrid.objects.update_or_create(
@@ -504,8 +504,36 @@ def refresh_iris_cloud_grid():
                 SiteName=f.Site,
                 SourceType=VSuperSummaries._meta.verbose_name
             )
+        log.info("Refreshed IrisCloudGrid from VSuperSummaries")
 
-        log.info("Refreshed IrisCloudGrid")
+        sql_query = """
+            SELECT
+                b.SiteName,
+                b.UpdateTime AS LatestPublish
+            FROM(
+                SELECT
+                    SiteName,
+                    MAX(UpdateTime) AS latest
+                FROM VAnonCloudRecords
+                WHERE UpdateTime > DATE_SUB(NOW(), INTERVAL 1 YEAR)
+                GROUP BY SiteName
+            )
+            AS a
+            INNER JOIN VAnonCloudRecords
+            AS b
+            ON b.SiteName = a.SiteName AND b.UpdateTime = a.latest
+            GROUP BY SiteName;
+        """
+        fetchset = VAnonCloudRecords.objects.using('iris_cloud').raw(sql_query)
+
+        for f in fetchset:
+            IrisCloudGrid.objects.update_or_create(
+                defaults={'UpdateTime': f.LatestPublish},
+                SiteName=f.Site,
+                SourceType=VAnonCloudRecords._meta.verbose_name
+            )    
+
+        log.info("Refreshed IrisCloudGrid from VAnonCloudRecords")
 
     except DatabaseError:
         log.exception('Error while trying to refresh IrisCloudGrid')

--- a/monitoring/db_update_sqlite.py
+++ b/monitoring/db_update_sqlite.py
@@ -45,12 +45,6 @@ from monitoring.benchmarks.models import (
     VNormalisedSummaries,
 )
 
-from monitoring.iris.models import (
-    IrisCloudGrid,
-    VSuperSummaries,
-    VAnonCloudRecords,
-)
-
 summaries_dict_standard = {
     "Site": [],
     "Month": [],
@@ -486,59 +480,6 @@ def refresh_gridsitesync_submithost():
         log.exception("Error while trying to refresh GridSiteSyncSubmitH")
 
 
-def refresh_iris_cloud_grid():
-    try:
-        sql_query = """
-            SELECT
-                Site,
-                max(LatestEndTime) AS LatestPublish
-            FROM VSuperSummaries
-            WHERE LatestEndTime > DATE_SUB(NOW(), INTERVAL 1 YEAR)
-            GROUP BY 1;
-        """
-        fetchset = VSuperSummaries.objects.using('iris_grid').raw(sql_query)
-
-        for f in fetchset:
-            IrisCloudGrid.objects.update_or_create(
-                defaults={'UpdateTime': f.LatestPublish},
-                SiteName=f.Site,
-                SourceType=VSuperSummaries._meta.verbose_name
-            )
-        log.info("Refreshed IrisCloudGrid from VSuperSummaries")
-
-        sql_query = """
-            SELECT
-                b.SiteName,
-                b.UpdateTime AS LatestPublish
-            FROM(
-                SELECT
-                    SiteName,
-                    MAX(UpdateTime) AS latest
-                FROM VAnonCloudRecords
-                WHERE UpdateTime > DATE_SUB(NOW(), INTERVAL 1 YEAR)
-                GROUP BY SiteName
-            )
-            AS a
-            INNER JOIN VAnonCloudRecords
-            AS b
-            ON b.SiteName = a.SiteName AND b.UpdateTime = a.latest
-            GROUP BY SiteName;
-        """
-        fetchset = VAnonCloudRecords.objects.using('iris_cloud').raw(sql_query)
-
-        for f in fetchset:
-            IrisCloudGrid.objects.update_or_create(
-                defaults={'UpdateTime': f.LatestPublish},
-                SiteName=f.Site,
-                SourceType=VAnonCloudRecords._meta.verbose_name
-            )    
-
-        log.info("Refreshed IrisCloudGrid from VAnonCloudRecords")
-
-    except DatabaseError:
-        log.exception('Error while trying to refresh IrisCloudGrid')
-
-
 if __name__ == "__main__":
     log.info('=====================')
 
@@ -547,8 +488,7 @@ if __name__ == "__main__":
     refresh_gridsitesync()
     refresh_gridsitesync_submithost()
     refresh_cloudsite()
-    # refresh_BenchmarksBySubmitHost()
-    refresh_iris_cloud_grid()
+    refresh_BenchmarksBySubmitHost()
 
     log.info(
         "Data retrieval and processing attempted. "

--- a/monitoring/db_update_sqlite.py
+++ b/monitoring/db_update_sqlite.py
@@ -45,6 +45,12 @@ from monitoring.benchmarks.models import (
     VNormalisedSummaries,
 )
 
+from monitoring.iris.models import (
+    IrisCloudGrid,
+    VSuperSummaries,
+    VAnonCloudRecords,
+)
+
 summaries_dict_standard = {
     "Site": [],
     "Month": [],
@@ -480,6 +486,31 @@ def refresh_gridsitesync_submithost():
         log.exception("Error while trying to refresh GridSiteSyncSubmitH")
 
 
+def refresh_iris_cloud_grid():
+    try:
+        sql_query = """
+            SELECT
+                Site,
+                max(LatestEndTime) AS LatestPublish
+            FROM VSuperSummaries
+            WHERE LatestEndTime > DATE_SUB(NOW(), INTERVAL 1 YEAR)
+            GROUP BY 1;
+        """
+        fetchset = VSuperSummaries.objects.using('grid').raw(sql_query)
+
+        for f in fetchset:
+            IrisCloudGrid.objects.update_or_create(
+                defaults={'UpdateTime': f.LatestPublish},
+                SiteName=f.Site,
+                SourceType=VSuperSummaries._meta.verbose_name
+            )
+
+        log.info("Refreshed IrisCloudGrid")
+
+    except DatabaseError:
+        log.exception('Error while trying to refresh IrisCloudGrid')
+
+
 if __name__ == "__main__":
     log.info('=====================')
 
@@ -488,7 +519,8 @@ if __name__ == "__main__":
     refresh_gridsitesync()
     refresh_gridsitesync_submithost()
     refresh_cloudsite()
-    refresh_BenchmarksBySubmitHost()
+    # refresh_BenchmarksBySubmitHost()
+    refresh_iris_cloud_grid()
 
     log.info(
         "Data retrieval and processing attempted. "

--- a/monitoring/iris/admin.py
+++ b/monitoring/iris/admin.py
@@ -1,0 +1,3 @@
+from django.contrib import admin
+
+# Register your models here.

--- a/monitoring/iris/apps.py
+++ b/monitoring/iris/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+
+class IrisConfig(AppConfig):
+    name = 'monitoring.iris'

--- a/monitoring/iris/models.py
+++ b/monitoring/iris/models.py
@@ -1,0 +1,31 @@
+from django.db import models
+
+
+class IrisCloudGrid(models.Model):
+    fetched = models.DateTimeField(auto_now=True)
+    SiteName = models.CharField(max_length=255)
+    SourceType = models.CharField(max_length=50)
+    UpdateTime = models.DateTimeField()
+
+    class Meta:
+        ordering = ('SiteName',)
+        # unique_together = ('SiteName', 'SourceType')
+
+class VSuperSummaries(models.Model):
+    Site = models.CharField(max_length=255, primary_key=True)
+    UpdateTime = models.DateTimeField()
+
+    class Meta:
+        managed = False
+        db_table = 'VSuperSummaries'
+        verbose_name = 'Grid site'
+
+
+class VAnonCloudRecords(models.Model):
+    Site = models.CharField(max_length=255, primary_key=True)
+    UpdateTime = models.DateTimeField()
+
+    class Meta:
+        managed = False
+        db_table = 'VAnonCloudRecords'
+        verbose_name = 'Cloud site'

--- a/monitoring/iris/models.py
+++ b/monitoring/iris/models.py
@@ -22,7 +22,7 @@ class VSuperSummaries(models.Model):
 
 
 class VAnonCloudRecords(models.Model):
-    Site = models.CharField(max_length=255, primary_key=True)
+    SiteName = models.CharField(max_length=255, primary_key=True)
     UpdateTime = models.DateTimeField()
 
     class Meta:

--- a/monitoring/iris/models.py
+++ b/monitoring/iris/models.py
@@ -1,7 +1,7 @@
 from django.db import models
 
 
-class IrisCloudGrid(models.Model):
+class IrisCloudAndGrid(models.Model):
     fetched = models.DateTimeField(auto_now=True)
     SiteName = models.CharField(max_length=255)
     SourceType = models.CharField(max_length=50)
@@ -9,7 +9,7 @@ class IrisCloudGrid(models.Model):
 
     class Meta:
         ordering = ('SiteName',)
-        # unique_together = ('SiteName', 'SourceType')
+        unique_together = ('SiteName', 'SourceType')
 
 class VSuperSummaries(models.Model):
     Site = models.CharField(max_length=255, primary_key=True)
@@ -18,7 +18,7 @@ class VSuperSummaries(models.Model):
     class Meta:
         managed = False
         db_table = 'VSuperSummaries'
-        verbose_name = 'Grid site'
+        verbose_name = 'Grid'
 
 
 class VAnonCloudRecords(models.Model):
@@ -28,4 +28,4 @@ class VAnonCloudRecords(models.Model):
     class Meta:
         managed = False
         db_table = 'VAnonCloudRecords'
-        verbose_name = 'Cloud site'
+        verbose_name = 'Cloud'

--- a/monitoring/iris/serializers.py
+++ b/monitoring/iris/serializers.py
@@ -1,16 +1,16 @@
 from rest_framework import serializers
 
-from monitoring.iris.models import IrisCloudGrid
+from monitoring.iris.models import IrisCloudAndGrid
 
 
-class IrisCloudGridSerializer(serializers.HyperlinkedModelSerializer):
+class IrisCloudAndGridSerializer(serializers.HyperlinkedModelSerializer):
     # Override default format with None so that Python datetime is used as
     # ouput format. Encoding will be determined by the renderer and can be
     # formatted by a template filter.
     UpdateTime = serializers.DateTimeField(format=None)
 
     class Meta:
-        model = IrisCloudGrid
+        model = IrisCloudAndGrid
         fields = (
             'SiteName',
             'SourceType',

--- a/monitoring/iris/serializers.py
+++ b/monitoring/iris/serializers.py
@@ -5,7 +5,7 @@ from monitoring.iris.models import IrisCloudAndGrid
 
 class IrisCloudAndGridSerializer(serializers.HyperlinkedModelSerializer):
     # Override default format with None so that Python datetime is used as
-    # ouput format. Encoding will be determined by the renderer and can be
+    # output format. Encoding will be determined by the renderer and can be
     # formatted by a template filter.
     UpdateTime = serializers.DateTimeField(format=None)
 

--- a/monitoring/iris/serializers.py
+++ b/monitoring/iris/serializers.py
@@ -1,0 +1,18 @@
+from rest_framework import serializers
+
+from monitoring.iris.models import IrisCloudGrid
+
+
+class IrisCloudGridSerializer(serializers.HyperlinkedModelSerializer):
+    # Override default format with None so that Python datetime is used as
+    # ouput format. Encoding will be determined by the renderer and can be
+    # formatted by a template filter.
+    UpdateTime = serializers.DateTimeField(format=None)
+
+    class Meta:
+        model = IrisCloudGrid
+        fields = (
+            'SiteName',
+            'SourceType',
+            'UpdateTime',
+        )

--- a/monitoring/iris/templates/iris_cloud_and_grid.html
+++ b/monitoring/iris/templates/iris_cloud_and_grid.html
@@ -11,7 +11,7 @@
 </head>
 
 <body>
-  <h2>Sites publishing cloud and grid accounting records in the last year</h2>
+  <h2>Sites publishing cloud and grid IRIS accounting records in the last year</h2>
   <p>Page last updated: {{ last_fetched|date:"Y-m-d H:i O" }}</p>
 
   <br/>
@@ -22,7 +22,7 @@
       <th class='tableheader'>Source type</th>
       <th class='tableheader'>Last updated</th>
     </tr>
-    {% for record in irisCloudGridData %}
+    {% for record in irisCloudAndGridData %}
     <tr onmouseover="this.className='highlight-row'" onmouseout="this.className='tabletext'" class="tabletext">
       <td>{{ record.SiteName }}</td>
       <td>{{ record.SourceType }}</td>

--- a/monitoring/iris/templates/iris_cloud_and_grid.html
+++ b/monitoring/iris/templates/iris_cloud_and_grid.html
@@ -11,7 +11,7 @@
 </head>
 
 <body>
-  <h2>Sites publishing cloud and grid IRIS accounting records in the last year</h2>
+  <h2>Sites publishing cloud and grid accounting records to IRIS Accounting in the last year</h2>
   <p>Page last updated: {{ last_fetched|date:"Y-m-d H:i O" }}</p>
 
   <br/>

--- a/monitoring/iris/templates/iris_cloud_grid.html
+++ b/monitoring/iris/templates/iris_cloud_grid.html
@@ -1,0 +1,35 @@
+{% load static %}
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <title>IRIS cloud and grid accounting records</title>
+  <link href="{% static 'stylesheet.css' %}" rel="stylesheet" type="text/css" />
+  <link href="{% static 'style.css' %}" rel="stylesheet" type="text/css" />
+</head>
+
+<body>
+  <h2>Sites publishing cloud and grid accounting records in the last year</h2>
+  <p>Page last updated: {{ last_fetched|date:"Y-m-d H:i O" }}</p>
+
+  <br/>
+
+  <table>
+    <tr>
+      <th class='tableheader'>Site</th>
+      <th class='tableheader'>Source type</th>
+      <th class='tableheader'>Last updated</th>
+    </tr>
+    {% for record in irisCloudGridData %}
+    <tr onmouseover="this.className='highlight-row'" onmouseout="this.className='tabletext'" class="tabletext">
+      <td>{{ record.SiteName }}</td>
+      <td>{{ record.SourceType }}</td>
+      <td>{{ record.UpdateTime|date:"Y-m-d H:i:s" }}</td>
+    </tr>
+    {% endfor %}
+  </table>
+</body>
+
+</html>

--- a/monitoring/iris/tests.py
+++ b/monitoring/iris/tests.py
@@ -1,0 +1,3 @@
+from django.test import TestCase
+
+# Create your tests here.

--- a/monitoring/iris/urls.py
+++ b/monitoring/iris/urls.py
@@ -1,0 +1,8 @@
+from rest_framework import routers
+
+from monitoring.iris import views
+
+router = routers.SimpleRouter()
+router.register('', views.IrisViewSet)
+
+urlpatterns = router.urls

--- a/monitoring/iris/views.py
+++ b/monitoring/iris/views.py
@@ -8,20 +8,20 @@ from rest_framework import viewsets
 from rest_framework.renderers import TemplateHTMLRenderer
 
 
-from monitoring.iris.models import IrisCloudGrid
+from monitoring.iris.models import IrisCloudAndGrid
 
-from monitoring.iris.serializers import IrisCloudGridSerializer
+from monitoring.iris.serializers import IrisCloudAndGridSerializer
 
 class IrisViewSet(viewsets.ReadOnlyModelViewSet):
     # Lower('SiteName'): sorts sites alphabetically, case-insensitively.
     # '-UpdateTime': sorts records within each site by UpdateTime in descending order (latest first).
-    queryset = IrisCloudGrid.objects.all().order_by(Lower('SiteName'), '-UpdateTime')
+    queryset = IrisCloudAndGrid.objects.all().order_by(Lower('SiteName'), '-UpdateTime')
 
-    serializer_class = IrisCloudGridSerializer
-    template_name = 'iris_cloud_grid.html'
+    serializer_class = IrisCloudAndGridSerializer
+    template_name = 'iris_cloud_and_grid.html'
 
     def list(self, request):
-        last_fetched = IrisCloudGrid.objects.aggregate(Max('fetched'))['fetched__max']
+        last_fetched = IrisCloudAndGrid.objects.aggregate(Max('fetched'))['fetched__max']
         if last_fetched is not None:
             print(last_fetched.replace(tzinfo=None), datetime.today() - timedelta(hours=1, seconds=20))
 
@@ -29,9 +29,8 @@ class IrisViewSet(viewsets.ReadOnlyModelViewSet):
 
         if type(request.accepted_renderer) is TemplateHTMLRenderer:
             response.data = {
-                'irisCloudGridData': response.data,
+                'irisCloudAndGridData': response.data,
                 'last_fetched': last_fetched,
             }
 
         return response
-

--- a/monitoring/iris/views.py
+++ b/monitoring/iris/views.py
@@ -1,29 +1,27 @@
-from django.shortcuts import render
 from datetime import datetime, timedelta
 
 from django.db.models import Max
 from django.db.models.functions import Lower
+from django.shortcuts import render
 
 from rest_framework import viewsets
 from rest_framework.renderers import TemplateHTMLRenderer
 
-
 from monitoring.iris.models import IrisCloudAndGrid
-
 from monitoring.iris.serializers import IrisCloudAndGridSerializer
+
 
 class IrisViewSet(viewsets.ReadOnlyModelViewSet):
     # Lower('SiteName'): sorts sites alphabetically, case-insensitively.
+    # '-SourceType': reverse order: grid before cloud
     # '-UpdateTime': sorts records within each site by UpdateTime in descending order (latest first).
-    queryset = IrisCloudAndGrid.objects.all().order_by(Lower('SiteName'), '-UpdateTime')
+    queryset = IrisCloudAndGrid.objects.all().order_by(Lower('SiteName'), '-SourceType', '-UpdateTime')
 
     serializer_class = IrisCloudAndGridSerializer
     template_name = 'iris_cloud_and_grid.html'
 
     def list(self, request):
         last_fetched = IrisCloudAndGrid.objects.aggregate(Max('fetched'))['fetched__max']
-        if last_fetched is not None:
-            print(last_fetched.replace(tzinfo=None), datetime.today() - timedelta(hours=1, seconds=20))
 
         response = super(IrisViewSet, self).list(request)
 

--- a/monitoring/iris/views.py
+++ b/monitoring/iris/views.py
@@ -1,0 +1,37 @@
+from django.shortcuts import render
+from datetime import datetime, timedelta
+
+from django.db.models import Max
+from django.db.models.functions import Lower
+
+from rest_framework import viewsets
+from rest_framework.renderers import TemplateHTMLRenderer
+
+
+from monitoring.iris.models import IrisCloudGrid
+
+from monitoring.iris.serializers import IrisCloudGridSerializer
+
+class IrisViewSet(viewsets.ReadOnlyModelViewSet):
+    # Lower('SiteName'): sorts sites alphabetically, case-insensitively.
+    # '-UpdateTime': sorts records within each site by UpdateTime in descending order (latest first).
+    queryset = IrisCloudGrid.objects.all().order_by(Lower('SiteName'), '-UpdateTime')
+
+    serializer_class = IrisCloudGridSerializer
+    template_name = 'iris_cloud_grid.html'
+
+    def list(self, request):
+        last_fetched = IrisCloudGrid.objects.aggregate(Max('fetched'))['fetched__max']
+        if last_fetched is not None:
+            print(last_fetched.replace(tzinfo=None), datetime.today() - timedelta(hours=1, seconds=20))
+
+        response = super(IrisViewSet, self).list(request)
+
+        if type(request.accepted_renderer) is TemplateHTMLRenderer:
+            response.data = {
+                'irisCloudGridData': response.data,
+                'last_fetched': last_fetched,
+            }
+
+        return response
+

--- a/monitoring/iris_db_update_sqlite.py
+++ b/monitoring/iris_db_update_sqlite.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
-`iris_db_update_sqlite.py` - Syncs data from external database into local SQLite DB.
-                      -  It will be run as a standalone operation via cron.
+- Syncs data from external database into local SQLite DB.
+- It will be run as a standalone operation via cron.
 """
 import configparser
 import logging
@@ -55,6 +55,10 @@ log = logging.getLogger(__name__)
 
 
 def refresh_iris_cloud_and_grid():
+    """
+    Refreshes the IrisCloudAndGrid table by performing necessary queries and updates.
+    Intended to be called from the main execution block or scheduled tasks.
+    """
     try:
         sql_query = """
             SELECT
@@ -108,13 +112,20 @@ def refresh_iris_cloud_and_grid():
         log.exception('Error while trying to refresh IrisCloudAndGrid')
 
 
-if __name__ == "__main__":
+def main():
+    """
+    Entry point for running the iris cloud and grid data refresh process.
+    """
     log.info('=====================')
 
     refresh_iris_cloud_and_grid()
 
     log.info(
-        "Data retrieval and processing attempted. "
-        "Check the above logs for details on the sync status"
+        "Data retrieval and processing attempted."
+        "Check the above logs for details on the sync status."
     )
     log.info('=====================')
+
+
+if __name__ == "__main__":
+    main()

--- a/monitoring/iris_db_update_sqlite.py
+++ b/monitoring/iris_db_update_sqlite.py
@@ -62,7 +62,7 @@ def refresh_iris_cloud_and_grid():
                 max(LatestEndTime) AS LatestPublish
             FROM VSuperSummaries
             WHERE LatestEndTime > DATE_SUB(NOW(), INTERVAL 1 YEAR)
-            AND (Site LIKE 'UK%' OR Site LIKE 'RAL-LCG2')
+            AND (Site LIKE 'UK%% OR Site LIKE 'RAL-LCG2')
             GROUP BY 1;
         """
         fetchset = VSuperSummaries.objects.using('iris_grid').raw(sql_query)

--- a/monitoring/iris_db_update_sqlite.py
+++ b/monitoring/iris_db_update_sqlite.py
@@ -62,7 +62,7 @@ def refresh_iris_cloud_and_grid():
                 max(LatestEndTime) AS LatestPublish
             FROM VSuperSummaries
             WHERE LatestEndTime > DATE_SUB(NOW(), INTERVAL 1 YEAR)
-            AND (Site LIKE 'UK%% OR Site LIKE 'RAL-LCG2')
+            AND (Site LIKE 'UK%%' OR Site LIKE 'RAL-LCG2')
             GROUP BY 1;
         """
         fetchset = VSuperSummaries.objects.using('iris_grid').raw(sql_query)
@@ -98,7 +98,7 @@ def refresh_iris_cloud_and_grid():
         for f in fetchset:
             IrisCloudAndGrid.objects.update_or_create(
                 defaults={'UpdateTime': make_aware(f.LatestPublish) if is_naive(f.LatestPublish) else f.LatestPublish},
-                SiteName=f.Site,
+                SiteName=f.SiteName,
                 SourceType=VAnonCloudRecords._meta.verbose_name
             )
 

--- a/monitoring/iris_db_update_sqlite.py
+++ b/monitoring/iris_db_update_sqlite.py
@@ -62,7 +62,7 @@ def refresh_iris_cloud_and_grid():
                 max(LatestEndTime) AS LatestPublish
             FROM VSuperSummaries
             WHERE LatestEndTime > DATE_SUB(NOW(), INTERVAL 1 YEAR)
-            AND (Site LIKE 'UK%' OR Site LIKE 'RAL-LCG2') 
+            AND (Site LIKE 'UK%' OR Site LIKE 'RAL-LCG2')
             GROUP BY 1;
         """
         fetchset = VSuperSummaries.objects.using('iris_grid').raw(sql_query)

--- a/monitoring/iris_db_update_sqlite.py
+++ b/monitoring/iris_db_update_sqlite.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+"""
+`iris_db_update_sqlite.py` - Syncs data from external database into local SQLite DB.
+                      -  It will be run as a standalone operation via cron.
+"""
+import configparser
+import logging
+import os
+import sys
+
+import django
+from django.db import DatabaseError
+from django.utils.timezone import make_aware, is_naive
+
+
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+
+# Find the root and the Django project
+sys.path.append(BASE_DIR)
+
+# Set up Django settings to run this `iris_db_update_sqlite.py` as standalone file
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "monitoring.settings")
+
+# Initialize and setup Django
+django.setup()
+
+
+# Cron jobs run in a minimal environment and lack access to Django settings.
+# To ensure proper model imports and database interactions, we MUST initialize and setup Django first.
+from monitoring.iris.models import (
+    IrisCloudAndGrid,
+    VSuperSummaries,
+    VAnonCloudRecords,
+)
+
+try:
+    # Read configuration from the file
+    cp = configparser.ConfigParser(interpolation=None)
+    file_path = os.path.join(BASE_DIR, 'monitoring', 'settings.ini')
+    cp.read(file_path)
+
+except (configparser.NoSectionError) as err:
+    print("Error in configuration file. Check that file exists first: %s" % err)
+    sys.exit(1)
+
+# Set up basic logging config
+logging.basicConfig(
+    filename=cp.get('common', 'iris_update_logfile'),
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - %(message)s'
+)
+
+# set up the logger
+log = logging.getLogger(__name__)
+
+
+def refresh_iris_cloud_and_grid():
+    try:
+        sql_query = """
+            SELECT
+                Site,
+                max(LatestEndTime) AS LatestPublish
+            FROM VSuperSummaries
+            WHERE LatestEndTime > DATE_SUB(NOW(), INTERVAL 1 YEAR)
+            AND (Site LIKE 'UK%' OR Site LIKE 'RAL-LCG2') 
+            GROUP BY 1;
+        """
+        fetchset = VSuperSummaries.objects.using('iris_grid').raw(sql_query)
+
+        for f in fetchset:
+            IrisCloudAndGrid.objects.update_or_create(
+                defaults={'UpdateTime': make_aware(f.LatestPublish) if is_naive(f.LatestPublish) else f.LatestPublish},
+                SiteName=f.Site,
+                SourceType=VSuperSummaries._meta.verbose_name
+            )
+        log.info("Refreshed IrisCloudAndGrid from VSuperSummaries")
+
+        sql_query = """
+            SELECT
+                b.SiteName,
+                b.UpdateTime AS LatestPublish
+            FROM(
+                SELECT
+                    SiteName,
+                    MAX(UpdateTime) AS latest
+                FROM VAnonCloudRecords
+                WHERE UpdateTime > DATE_SUB(NOW(), INTERVAL 1 YEAR)
+                GROUP BY SiteName
+            )
+            AS a
+            INNER JOIN VAnonCloudRecords
+            AS b
+            ON b.SiteName = a.SiteName AND b.UpdateTime = a.latest
+            GROUP BY SiteName;
+        """
+        fetchset = VAnonCloudRecords.objects.using('iris_cloud').raw(sql_query)
+
+        for f in fetchset:
+            IrisCloudAndGrid.objects.update_or_create(
+                defaults={'UpdateTime': make_aware(f.LatestPublish) if is_naive(f.LatestPublish) else f.LatestPublish},
+                SiteName=f.Site,
+                SourceType=VAnonCloudRecords._meta.verbose_name
+            )
+
+        log.info("Refreshed IrisCloudAndGrid from VAnonCloudRecords")
+
+    except DatabaseError:
+        log.exception('Error while trying to refresh IrisCloudAndGrid')
+
+
+if __name__ == "__main__":
+    log.info('=====================')
+
+    refresh_iris_cloud_and_grid()
+
+    log.info(
+        "Data retrieval and processing attempted. "
+        "Check the above logs for details on the sync status"
+    )
+    log.info('=====================')

--- a/monitoring/settings.ini
+++ b/monitoring/settings.ini
@@ -32,3 +32,25 @@ port = 3306
 name =
 username = root
 password =
+
+# Information about the database connection - iris_cloud
+[db_iris_cloud]
+# type of database refers to the Django db backend
+backend = django.db.backends.mysql
+
+hostname = localhost
+port = 3306
+name =
+username = root
+password =
+
+# Information about the database connection - iris_grid
+[db_iris_grid]
+# type of database refers to the Django db backend
+backend = django.db.backends.mysql
+
+hostname = localhost
+port = 3306
+name =
+username = root
+password =

--- a/monitoring/settings.ini
+++ b/monitoring/settings.ini
@@ -10,6 +10,9 @@ allowed_hosts =
 # Path to the log file for `db_update_sqlite.py` execution info.
 logfile =
 
+# Path to the log file for `iris_db_update_sqlite.py` execution info.
+iris_update_logfile =
+
 # Information about the database connection - grid
 [db_grid]
 # type of database - refers to the Django db backend
@@ -33,7 +36,7 @@ name =
 username = root
 password =
 
-# Information about the database connection - iris_cloud
+# Information about the iris_cloud database connection used by iris_db_update_sqlite.py
 [db_iris_cloud]
 # type of database refers to the Django db backend
 backend = django.db.backends.mysql
@@ -44,7 +47,7 @@ name =
 username = root
 password =
 
-# Information about the database connection - iris_grid
+# Information about the iris_grid database connection used by iris_db_update_sqlite.py
 [db_iris_grid]
 # type of database refers to the Django db backend
 backend = django.db.backends.mysql

--- a/monitoring/settings.py
+++ b/monitoring/settings.py
@@ -78,6 +78,7 @@ INSTALLED_APPS = [
     'monitoring.publishing',
     'monitoring.availability',
     'monitoring.benchmarks',
+    'monitoring.iris',
 ]
 
 REST_FRAMEWORK = {

--- a/monitoring/settings.py
+++ b/monitoring/settings.py
@@ -58,6 +58,22 @@ try:
             'USER': cp.get('db_cloud', 'username'),
             'PASSWORD': cp.get('db_cloud', 'password'),
         },
+        'iris_grid': {
+            'ENGINE': cp.get('db_iris_grid', 'backend'),
+            'HOST': cp.get('db_iris_grid', 'hostname'),
+            'PORT': cp.get('db_iris_grid', 'port'),
+            'NAME': cp.get('db_iris_grid', 'name'),
+            'USER': cp.get('db_iris_grid', 'username'),
+            'PASSWORD': cp.get('db_iris_grid', 'password'),
+        },
+        'iris_cloud': {
+            'ENGINE': cp.get('db_iris_cloud', 'backend'),
+            'HOST': cp.get('db_iris_cloud', 'hostname'),
+            'PORT': cp.get('db_iris_cloud', 'port'),
+            'NAME': cp.get('db_iris_cloud', 'name'),
+            'USER': cp.get('db_iris_cloud', 'username'),
+            'PASSWORD': cp.get('db_iris_cloud', 'password'),
+        },
     }
 
 except (configparser.NoSectionError) as err:

--- a/monitoring/templates/home.html
+++ b/monitoring/templates/home.html
@@ -30,6 +30,12 @@
     sites last published and what accounting script they are using.
 </li></ul></p>
 
+<h2>IRIS Cloud and Grid Accounting</h2>
+<p><ul><li>
+    <a href="{% url 'iriscloudandgrid-list' %}">{% url 'iriscloudandgrid-list' %}</a> - An overview of when IRIS cloud and grid
+    sites last published and what accounting script they are using.
+</li></ul></p>
+
 <h2>Return format</h2>
 <p>
     The views above return HTML by default, but can be set to return JSON by adding <code>?format=json</code> at the end of the URL.

--- a/monitoring/templates/home.html
+++ b/monitoring/templates/home.html
@@ -33,7 +33,7 @@
 <h2>IRIS Cloud and Grid Accounting</h2>
 <p><ul><li>
     <a href="{% url 'iriscloudandgrid-list' %}">{% url 'iriscloudandgrid-list' %}</a> - An overview of when IRIS cloud and grid
-    sites last published and what accounting script they are using.
+    sites last published.
 </li></ul></p>
 
 <h2>Return format</h2>

--- a/monitoring/urls.py
+++ b/monitoring/urls.py
@@ -8,5 +8,6 @@ urlpatterns = [
     path('availability/', include('monitoring.availability.urls')),
     path('publishing/', include('monitoring.publishing.urls')),
     path('benchmarks/', include('monitoring.benchmarks.urls')),
+    path('iris/', include('monitoring.iris.urls')),
     path('api-auth/', include('rest_framework.urls', namespace='rest_framework')),
 ]


### PR DESCRIPTION
Resolved https://stfc.atlassian.net/browse/GT-1153

- A new app called `iris`
- `/iris/` link in index page
- A page `/iris` to show sites publishing cloud and grid accounting records to IRIS Accounting in the last year
- Only showing UK sites

Index page
<img width="1194" height="437" alt="image" src="https://github.com/user-attachments/assets/6401c546-178d-4edd-9c91-d2fcf86e7abc" />


IRIS page
<img width="619" height="525" alt="image" src="https://github.com/user-attachments/assets/7f561413-71b2-4689-b531-65808ab37e3f" />


Query execution time
<img width="1404" height="107" alt="image" src="https://github.com/user-attachments/assets/45fb1783-c7f3-4686-8e5b-132888718298" />

