### PR TITLE
Various fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# monitoring
-Monitoring system for APEL servers
+# APEL Data Validation System
+Monitoring system for APEL servers. Built using Django and Django REST framework.

--- a/monitoring/benchmarks/templates/benchmarks_by_submithost.html
+++ b/monitoring/benchmarks/templates/benchmarks_by_submithost.html
@@ -11,7 +11,7 @@
 </head>
 
 <body>
-  <h2>Sites publishing benchmark records in last 3 months</h2>
+  <h2>Sites publishing benchmark records in last 2 months</h2>
   <p>Page last updated: {{ last_fetched|date:"Y-m-d H:i O" }}</p>
   <table>
     <tr>

--- a/monitoring/benchmarks/templates/benchmarks_by_submithost.html
+++ b/monitoring/benchmarks/templates/benchmarks_by_submithost.html
@@ -11,7 +11,7 @@
 </head>
 
 <body>
-  <h2>Sites publishing benchmark records in last 2 months</h2>
+  <h2>Sites publishing benchmark records in the last two months</h2>
   <p>Page last updated: {{ last_fetched|date:"Y-m-d H:i O" }}</p>
   <table>
     <tr>

--- a/monitoring/benchmarks/views.py
+++ b/monitoring/benchmarks/views.py
@@ -22,8 +22,6 @@ class BenchmarksViewSet(viewsets.ReadOnlyModelViewSet):
 
     def list(self, request):
         last_fetched = BenchmarksBySubmithost.objects.aggregate(Max('fetched'))['fetched__max']
-        if last_fetched is not None:
-            print(last_fetched.replace(tzinfo=None), datetime.today() - timedelta(hours=1, seconds=20))
 
         response = super(BenchmarksViewSet, self).list(request)
 

--- a/monitoring/db_update_sqlite.py
+++ b/monitoring/db_update_sqlite.py
@@ -319,21 +319,30 @@ def refresh_BenchmarksBySubmitHost_from_view(view_name):
         """
         elif view_name == 'VJobRecords':
             sql_query = f"""
-            SELECT DISTINCT v.Site, v.SubmitHost, v.ServiceLevelType, v.ServiceLevel, v.UpdateTime AS LatestPublish
-            FROM {view_name} AS v
-            JOIN (
-                SELECT Site, SubmitHost, MAX(UpdateTime) AS LatestPublish
-                FROM {view_name}
-                WHERE EndTime > DATE_SUB(NOW(), INTERVAL 3 MONTH)
-                      AND UpdateTime > DATE_SUB(NOW(), INTERVAL 3 MONTH)
-                GROUP BY Site, SubmitHost, ServiceLevelType, ServiceLevel
-            ) AS latest
-            ON v.Site = latest.Site
-               AND v.SubmitHost = latest.SubmitHost
-               AND v.UpdateTime = latest.LatestPublish
-            WHERE v.EndTime > DATE_SUB(NOW(), INTERVAL 3 MONTH)
-                  AND v.UpdateTime > DATE_SUB(NOW(), INTERVAL 3 MONTH);
-        """
+                WITH latest AS (
+                SELECT
+                    Site,
+                    SubmitHost,
+                    ServiceLevelType,
+                    ServiceLevel,
+                    UpdateTime,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY Site, SubmitHost
+                        ORDER BY EndTime DESC, UpdateTime DESC
+                    ) AS rn
+                FROM VJobRecords
+                WHERE EndTime >= NOW() - INTERVAL 2 MONTH
+                    AND UpdateTime >= NOW() - INTERVAL 2 MONTH
+                )
+                SELECT
+                    Site,
+                    SubmitHost,
+                    ServiceLevelType,
+                    ServiceLevel,
+                    UpdateTime AS LatestPublish
+                FROM latest
+                WHERE rn = 1;
+            """
         elif view_name == 'VNormalisedSummaries':
             sql_query = f"""
             SELECT DISTINCT v.Site, v.SubmitHost, v.ServiceLevelType, ROUND(v.NormalisedWallDuration / v.WallDuration, 3) AS ServiceLevel, v.UpdateTime AS LatestPublish

--- a/monitoring/db_update_sqlite.py
+++ b/monitoring/db_update_sqlite.py
@@ -176,31 +176,30 @@ def refresh_gridsite():
 def refresh_cloudsite():
     try:
         sql_query = """
-            SELECT
-                b.SiteName,
-                COUNT(DISTINCT VMUUID) as VMs,
-                CloudType,
-                b.UpdateTime
-            FROM(
+            WITH ranked AS (
                 SELECT
                     SiteName,
-                    MAX(UpdateTime) AS latest
+                    CloudType,
+                    UpdateTime,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY SiteName
+                        ORDER BY UpdateTime DESC
+                    ) AS rn
                 FROM VAnonCloudRecords
-                WHERE UpdateTime > DATE_SUB(NOW(), INTERVAL 1 YEAR)
-                GROUP BY SiteName
+                WHERE UpdateTime >= CURRENT_TIMESTAMP - INTERVAL 6 MONTH
             )
-            AS a
-            INNER JOIN VAnonCloudRecords
-            AS b
-            ON b.SiteName = a.SiteName AND b.UpdateTime = a.latest
-            GROUP BY SiteName;
+            SELECT
+                SiteName,
+                CloudType,
+                UpdateTime
+            FROM ranked
+            WHERE rn = 1;
         """
         fetchset = VAnonCloudRecord.objects.using('cloud').raw(sql_query)
 
         for f in fetchset:
             CloudSite.objects.update_or_create(
                 defaults={
-                    'Vms': f.VMs,
                     'Script': f.CloudType,
                     'updated': f.UpdateTime
                 },

--- a/monitoring/db_update_sqlite.py
+++ b/monitoring/db_update_sqlite.py
@@ -156,7 +156,7 @@ def refresh_gridsite():
                 Site,
                 max(LatestEndTime) AS LatestPublish
             FROM VSuperSummaries
-            WHERE LatestEndTime > DATE_SUB(NOW(), INTERVAL 1 YEAR)
+            WHERE LatestEndTime >= NOW() - INTERVAL 1 YEAR
             GROUP BY 1;
         """
         fetchset = VSuperSummaries.objects.using('grid').raw(sql_query)
@@ -186,7 +186,7 @@ def refresh_cloudsite():
                         ORDER BY UpdateTime DESC
                     ) AS rn
                 FROM VAnonCloudRecords
-                WHERE UpdateTime >= CURRENT_TIMESTAMP - INTERVAL 6 MONTH
+                WHERE UpdateTime >= NOW() - INTERVAL 6 MONTH
             )
             SELECT
                 SiteName,

--- a/monitoring/db_update_sqlite.py
+++ b/monitoring/db_update_sqlite.py
@@ -304,35 +304,45 @@ def refresh_BenchmarksBySubmitHost_from_view(view_name):
     try:
         if view_name == 'VSummaries':
             sql_query = f"""
-            SELECT DISTINCT v.Site, v.SubmitHost, v.ServiceLevelType, v.ServiceLevel, v.UpdateTime AS LatestPublish
-            FROM {view_name} AS v
-            JOIN (
-                SELECT Site, SubmitHost, MAX(UpdateTime) AS LatestPublish
-                FROM {view_name}
-                WHERE UpdateTime > DATE_SUB(NOW(), INTERVAL 3 MONTH)
-                GROUP BY Site, SubmitHost, ServiceLevelType, ServiceLevel
-            ) AS latest
-            ON v.Site = latest.Site
-               AND v.SubmitHost = latest.SubmitHost
-               AND v.UpdateTime = latest.LatestPublish
-            WHERE v.UpdateTime > DATE_SUB(NOW(), INTERVAL 3 MONTH);
-        """
-        elif view_name == 'VJobRecords':
-            sql_query = f"""
                 WITH latest AS (
+                    SELECT
+                        Site,
+                        SubmitHost,
+                        ServiceLevelType,
+                        ServiceLevel,
+                        UpdateTime,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY Site, SubmitHost
+                            ORDER BY Year DESC, Month DESC, UpdateTime DESC
+                        ) AS rn
+                    FROM VSummaries
+                    WHERE UpdateTime >= NOW() - INTERVAL 2 MONTH
+                )
                 SELECT
                     Site,
                     SubmitHost,
                     ServiceLevelType,
                     ServiceLevel,
-                    UpdateTime,
-                    ROW_NUMBER() OVER (
-                        PARTITION BY Site, SubmitHost
-                        ORDER BY EndTime DESC, UpdateTime DESC
-                    ) AS rn
-                FROM VJobRecords
-                WHERE EndTime >= NOW() - INTERVAL 2 MONTH
-                    AND UpdateTime >= NOW() - INTERVAL 2 MONTH
+                    UpdateTime AS LatestPublish
+                FROM latest
+                WHERE rn = 1;
+            """
+        elif view_name == 'VJobRecords':
+            sql_query = f"""
+                WITH latest AS (
+                    SELECT
+                        Site,
+                        SubmitHost,
+                        ServiceLevelType,
+                        ServiceLevel,
+                        UpdateTime,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY Site, SubmitHost
+                            ORDER BY EndTime DESC, UpdateTime DESC
+                        ) AS rn
+                    FROM VJobRecords
+                    WHERE EndTime >= NOW() - INTERVAL 2 MONTH
+                        AND UpdateTime >= NOW() - INTERVAL 2 MONTH
                 )
                 SELECT
                     Site,
@@ -345,21 +355,31 @@ def refresh_BenchmarksBySubmitHost_from_view(view_name):
             """
         elif view_name == 'VNormalisedSummaries':
             sql_query = f"""
-            SELECT DISTINCT v.Site, v.SubmitHost, v.ServiceLevelType, ROUND(v.NormalisedWallDuration / v.WallDuration, 3) AS ServiceLevel, v.UpdateTime AS LatestPublish
-            FROM {view_name} AS v
-            JOIN (
-                SELECT Site, SubmitHost, MAX(UpdateTime) AS LatestPublish, ROUND(NormalisedWallDuration / WallDuration, 3) AS ServiceLevel
-                FROM {view_name}
-                WHERE UpdateTime > DATE_SUB(NOW(), INTERVAL 3 MONTH)
-                    AND WallDuration > 0
-                GROUP BY Site, SubmitHost, ServiceLevelType, ServiceLevel
-            ) AS latest
-            ON v.Site = latest.Site
-               AND v.SubmitHost = latest.SubmitHost
-               AND v.UpdateTime = latest.LatestPublish
-            WHERE v.UpdateTime > DATE_SUB(NOW(), INTERVAL 3 MONTH)
-                  AND v.WallDuration > 0;
-        """
+                WITH latest AS (
+                    SELECT
+                        Site,
+                        SubmitHost,
+                        ServiceLevelType,
+                        NormalisedWallDuration,
+                        WallDuration,
+                        UpdateTime,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY Site, SubmitHost
+                            ORDER BY Year DESC, Month DESC, UpdateTime DESC
+                        ) AS rn
+                    FROM VNormalisedSummaries
+                    WHERE UpdateTime >= NOW() - INTERVAL 2 MONTH
+                        AND WallDuration > 0
+                )
+                SELECT
+                    Site,
+                    SubmitHost,
+                    ServiceLevelType,
+                    ROUND(NormalisedWallDuration / WallDuration, 3) AS ServiceLevel,
+                    UpdateTime AS LatestPublish
+                FROM latest
+                WHERE rn = 1;
+            """
         else:
             log.warning(f"Unknown view name: {view_name}")
             return

--- a/monitoring/iris/templates/iris_cloud_and_grid.html
+++ b/monitoring/iris/templates/iris_cloud_and_grid.html
@@ -11,7 +11,7 @@
 </head>
 
 <body>
-  <h2>Sites publishing cloud and grid accounting records to IRIS Accounting in the last year</h2>
+  <h2>Sites publishing cloud and grid accounting records to IRIS Accounting in the last six months</h2>
   <p>Page last updated: {{ last_fetched|date:"Y-m-d H:i O" }}</p>
 
   <br/>

--- a/monitoring/iris_db_update_sqlite.py
+++ b/monitoring/iris_db_update_sqlite.py
@@ -65,7 +65,7 @@ def refresh_iris_cloud_and_grid():
                 Site,
                 max(LatestEndTime) AS LatestPublish
             FROM VSuperSummaries
-            WHERE LatestEndTime > DATE_SUB(NOW(), INTERVAL 6 MONTH)
+            WHERE LatestEndTime >= NOW() - INTERVAL 6 MONTH
             AND (Site LIKE 'UK%%' OR Site LIKE 'RAL-LCG2')
             GROUP BY 1;
         """
@@ -84,7 +84,7 @@ def refresh_iris_cloud_and_grid():
                 SiteName,
                 MAX(UpdateTime) AS LatestPublish
             FROM VAnonCloudRecords
-            WHERE UpdateTime > NOW() - INTERVAL 6 MONTH
+            WHERE UpdateTime >= NOW() - INTERVAL 6 MONTH
             GROUP BY SiteName;
         """
         fetchset = VAnonCloudRecords.objects.using('iris_cloud').raw(sql_query)

--- a/monitoring/iris_db_update_sqlite.py
+++ b/monitoring/iris_db_update_sqlite.py
@@ -65,7 +65,7 @@ def refresh_iris_cloud_and_grid():
                 Site,
                 max(LatestEndTime) AS LatestPublish
             FROM VSuperSummaries
-            WHERE LatestEndTime > DATE_SUB(NOW(), INTERVAL 1 YEAR)
+            WHERE LatestEndTime > DATE_SUB(NOW(), INTERVAL 6 MONTH)
             AND (Site LIKE 'UK%%' OR Site LIKE 'RAL-LCG2')
             GROUP BY 1;
         """
@@ -81,20 +81,10 @@ def refresh_iris_cloud_and_grid():
 
         sql_query = """
             SELECT
-                b.SiteName,
-                b.UpdateTime AS LatestPublish
-            FROM(
-                SELECT
-                    SiteName,
-                    MAX(UpdateTime) AS latest
-                FROM VAnonCloudRecords
-                WHERE UpdateTime > DATE_SUB(NOW(), INTERVAL 1 YEAR)
-                GROUP BY SiteName
-            )
-            AS a
-            INNER JOIN VAnonCloudRecords
-            AS b
-            ON b.SiteName = a.SiteName AND b.UpdateTime = a.latest
+                SiteName,
+                MAX(UpdateTime) AS LatestPublish
+            FROM VAnonCloudRecords
+            WHERE UpdateTime > NOW() - INTERVAL 6 MONTH
             GROUP BY SiteName;
         """
         fetchset = VAnonCloudRecords.objects.using('iris_cloud').raw(sql_query)

--- a/monitoring/publishing/templates/cloudsites.html
+++ b/monitoring/publishing/templates/cloudsites.html
@@ -10,12 +10,11 @@
 </head>
 
 <body>
-  <h2>Sites publishing cloud accounting records in the last year</h2>
+  <h2>Sites publishing cloud accounting records in the six months</h2>
   <p>Data last fetched: {{ last_fetched|date:"Y-m-d H:i O" }}</p>
   <table>
     <tr>
       <th class='tableheader'>Site</th>
-      <th class='tableheader'>VMsInLastUpdate</th>
       <th class='tableheader'>CloudType</th>
       <th class='tableheader'>LastUpdated</th>
       <th class='tableheader'>Publication Status</th>
@@ -23,7 +22,6 @@
     {% for site in sites %}
     <tr onmouseover="this.className='highlight-row'" onmouseout="this.className='tabletext'" class="tabletext">
       <td>{{ site.SiteName }}</td>
-      <td>{{ site.Vms }}</td>
       <td>{{ site.Script }}</td>
       <td>{{ site.updated|date:"Y-m-d H:i:s" }}</td>
       <td>{{ site.stdout }}</td>

--- a/monitoring/publishing/templates/cloudsites.html
+++ b/monitoring/publishing/templates/cloudsites.html
@@ -10,7 +10,7 @@
 </head>
 
 <body>
-  <h2>Sites publishing cloud accounting records in the six months</h2>
+  <h2>Sites publishing cloud accounting records in the last six months</h2>
   <p>Data last fetched: {{ last_fetched|date:"Y-m-d H:i O" }}</p>
   <table>
     <tr>

--- a/monitoring/publishing/views.py
+++ b/monitoring/publishing/views.py
@@ -63,8 +63,6 @@ class GridSiteViewSet(viewsets.ReadOnlyModelViewSet):
 
     def list(self, request):
         last_fetched = GridSite.objects.aggregate(Max('fetched'))['fetched__max']
-        if last_fetched is not None:
-            print(last_fetched.replace(tzinfo=None), datetime.today() - timedelta(hours=1, seconds=20))
 
         final_response = []
         response = super(GridSiteViewSet, self).list(request)
@@ -85,8 +83,6 @@ class GridSiteViewSet(viewsets.ReadOnlyModelViewSet):
     def retrieve(self, request, SiteName=None):
         last_fetched = GridSite.objects.aggregate(Max('fetched'))['fetched__max']
         # If there's no data then last_fetched is None.
-        if last_fetched is not None:
-            print(last_fetched.replace(tzinfo=None), datetime.today() - timedelta(hours=1, seconds=20))
 
         response = super(GridSiteViewSet, self).retrieve(request)
         date = response.data['updated'].replace(tzinfo=None)
@@ -124,9 +120,6 @@ class GridSiteSyncViewSet(viewsets.ReadOnlyModelViewSet):
     def list(self, request):
         last_fetched = GridSiteSync.objects.aggregate(Max('fetched'))['fetched__max']
 
-        if last_fetched is not None:
-            print(last_fetched.replace(tzinfo=None), datetime.today() - timedelta(hours=1, seconds=20))
-
         response = super(GridSiteSyncViewSet, self).list(request)
         response.data = {
             'records': response.data,
@@ -136,9 +129,6 @@ class GridSiteSyncViewSet(viewsets.ReadOnlyModelViewSet):
 
     def retrieve(self, request, SiteName=None):
         last_fetched = GridSiteSync.objects.aggregate(Max('fetched'))['fetched__max']
-
-        if last_fetched is not None:
-            print(last_fetched.replace(tzinfo=None), datetime.today() - timedelta(hours=1, seconds=20))
 
         sites_list_qs = GridSiteSync.objects.filter(SiteName=SiteName)
         sites_list_serializer = self.get_serializer(sites_list_qs, many=True)
@@ -186,9 +176,6 @@ class GridSiteSyncSubmitHViewSet(MultipleFieldLookupMixin, viewsets.ReadOnlyMode
     def retrieve(self, request, SiteName=None, YearMonth=None):
         last_fetched = GridSiteSyncSubmitH.objects.aggregate(Max('fetched'))['fetched__max']
 
-        if last_fetched is not None:
-            print(last_fetched.replace(tzinfo=None), datetime.today() - timedelta(hours=1, seconds=20))
-
         site_and_year_queryset = GridSiteSyncSubmitH.objects.filter(
             SiteName=SiteName,
             YearMonth=YearMonth
@@ -212,8 +199,6 @@ class CloudSiteViewSet(viewsets.ReadOnlyModelViewSet):
 
     def list(self, request):
         last_fetched = CloudSite.objects.aggregate(Max('fetched'))['fetched__max']
-        if last_fetched is not None:
-            print(last_fetched.replace(tzinfo=None), datetime.today() - timedelta(hours=1, seconds=20))
 
         final_response = []
         response = super(CloudSiteViewSet, self).list(request)
@@ -233,7 +218,6 @@ class CloudSiteViewSet(viewsets.ReadOnlyModelViewSet):
 
     def retrieve(self, request, SiteName=None):
         last_fetched = CloudSite.objects.aggregate(Max('fetched'))['fetched__max']
-        print(last_fetched.replace(tzinfo=None), datetime.today() - timedelta(hours=1, seconds=20))
 
         response = super(CloudSiteViewSet, self).retrieve(request)
         # Wrap data in a dict so that it can display in template.

--- a/monitoring/publishing/views.py
+++ b/monitoring/publishing/views.py
@@ -40,15 +40,15 @@ def update_dict_stdout_and_returncode(single_dict, date, warn_days=7, crit_days=
     diff_days = (today - date).days
     formatted_date = date.strftime("%Y-%m-%d")
 
-    if diff_days <= warn_days:
-        status = "OK"
-        returncode = 0
+    if diff_days > crit_days:
+        status = "CRITICAL"
+        returncode = 2
     elif diff_days > warn_days:
         status = "WARNING"
         returncode = 1
-    elif diff_days > crit_days:
-        status = "CRITICAL"
-        returncode = 2
+    else:
+        status = "OK"
+        returncode = 0
 
     single_dict.update({
         'returncode': returncode,

--- a/monitoring/publishing/views.py
+++ b/monitoring/publishing/views.py
@@ -26,11 +26,11 @@ from monitoring.publishing.serializers import (
     GridSiteSyncSubmitHSerializer
 )
 
-def update_dict_stdout_and_returncode(single_dict, date, days=7):
+def update_dict_stdout_and_returncode(single_dict, date, warn_days=7, crit_days=31):
     today = datetime.today()
 
-    # Handle future dates
-    if date > today:
+    # Handle null values
+    if date is None:
         single_dict.update({
             'returncode': 3,
             'stdout': "UNKNOWN"
@@ -40,12 +40,15 @@ def update_dict_stdout_and_returncode(single_dict, date, days=7):
     diff_days = (today - date).days
     formatted_date = date.strftime("%Y-%m-%d")
 
-    if diff_days <= days:
+    if diff_days <= warn_days:
         status = "OK"
         returncode = 0
-    else:
+    elif diff_days > warn_days:
         status = "WARNING"
         returncode = 1
+    elif diff_days > crit_days:
+        status = "CRITICAL"
+        returncode = 2
 
     single_dict.update({
         'returncode': returncode,


### PR DESCRIPTION
Resolves GT-1240
Resolves #63 (by speeding up the queries to an acceptable level)

This PR does the following:
- Replace some of the queries with much faster ones.
- Fixes some of the logic around which result is fetched for the benchmarks page so that you actually get the most relevant row for each site and submithost.
- Removes redundant `print()` that were used when debugging during initial creation.
- Fixes the comparisons for the status evaluation to allow future dates and add a critical level.
- Tweaks the readme.
- Also applies a small SQL change to the IRIS update script to try and improve its performance a bit.

 ## Speed comparison
### Before
Over 1 hour.
```
2025-11-27 07:01:02,050 - INFO - =====================
2025-11-27 07:01:11,655 - INFO - Refreshed GridSite
2025-11-27 07:01:31,630 - INFO - Refreshed GridSiteSync
2025-11-27 07:03:01,444 - INFO - Refreshed GridSiteSyncSubmitH
2025-11-27 07:17:13,359 - INFO - Refreshed CloudSite
2025-11-27 07:17:41,885 - INFO - Refreshed BenchmarksBySubmitHost from VSummaries
2025-11-27 08:17:42,443 - INFO - Refreshed BenchmarksBySubmitHost from VJobRecords
2025-11-27 08:17:51,911 - INFO - Refreshed BenchmarksBySubmitHost from VNormalisedSummaries
2025-11-27 08:17:51,911 - INFO - Data retrieval and processing attempted. Check the above logs for details on the sync status
2025-11-27 08:17:51,911 - INFO - =====================
```

### After
Less than 5 minutes.
```
2025-12-12 20:47:16,860 - INFO - =====================
2025-12-12 20:47:19,483 - INFO - Refreshed GridSite
2025-12-12 20:47:32,894 - INFO - Refreshed GridSiteSync
2025-12-12 20:48:29,054 - INFO - Refreshed GridSiteSyncSubmitH
2025-12-12 20:49:06,731 - INFO - Refreshed CloudSite
2025-12-12 20:49:07,980 - INFO - Refreshed BenchmarksBySubmitHost from VSummaries
2025-12-12 20:51:31,971 - INFO - Refreshed BenchmarksBySubmitHost from VJobRecords
2025-12-12 20:51:32,210 - INFO - Refreshed BenchmarksBySubmitHost from VNormalisedSummaries
2025-12-12 20:51:32,210 - INFO - Data retrieval and processing attempted. Check the above logs for details on the sync status
2025-12-12 20:51:32,210 - INFO - =====================
```