### PR TITLE
Add publication status for individual cloud site

### DIFF
--- a/monitoring/publishing/views.py
+++ b/monitoring/publishing/views.py
@@ -223,6 +223,9 @@ class CloudSiteViewSet(viewsets.ReadOnlyModelViewSet):
         last_fetched = CloudSite.objects.aggregate(Max('fetched'))['fetched__max']
 
         response = super(CloudSiteViewSet, self).retrieve(request)
+        date = response.data['updated'].replace(tzinfo=None)
+        response.data = update_dict_stdout_and_returncode(response.data, date)
+
         # Wrap data in a dict so that it can display in template.
         if type(request.accepted_renderer) is TemplateHTMLRenderer:
             # Single result put in list to work with same HTML template.
@@ -230,8 +233,5 @@ class CloudSiteViewSet(viewsets.ReadOnlyModelViewSet):
                 'sites': [response.data],
                 'last_fetched': last_fetched
             }
-
-        response.data['returncode'] = 3
-        response.data['stdout'] = "UNKNOWN"
 
         return response


### PR DESCRIPTION
Resolved GT-1244

Publication status added for individual cloud site. http://host-172-16-103-240.nubes.stfc.ac.uk/publishing/cloud/CENI/

<img width="657" height="199" alt="image" src="https://github.com/user-attachments/assets/5f2eb0c8-d9d2-462c-9f06-9f459cdbd2d7" />
