### PR TITLE
Remove Loader startup/shutdown as it's not needed

### DIFF
--- a/monitoring/validator/views.py
+++ b/monitoring/validator/views.py
@@ -141,11 +141,7 @@ def load(record: str) -> str:
 
         loader = Loader(qpath, record, db_backend, db_host, db_port, db_name, db_username, db_password, pidfile)
 
-        loader.startup()
-
         loader.load_msg(record, signer)
-
-        loader.shutdown()
 
         return("Record(s) will load successfully!")
 


### PR DESCRIPTION
We don't need to startup and shutdown the Loader as we're not running it as a Daemon. We're invoking its `load_msg` method and passing it a message to load directly.