### PR TITLE
Relax the test ever so slightly

### DIFF
--- a/monitoring/db_update_sqlite.py
+++ b/monitoring/db_update_sqlite.py
@@ -152,7 +152,7 @@ def determine_sync_status(f):
     diff = abs(RecordCountPublished - RecordCountInDb)
     rel_diff1 = diff/RecordCountInDb
     rel_diff2 = diff/RecordCountPublished
-    if RecordCountPublished > RecordCountInDb or rel_diff1 < 0.01 or rel_diff2 < 0.01:
+    if RecordCountPublished > RecordCountInDb or rel_diff1 <= 0.01 or rel_diff2 <= 0.01:
         return "OK"
 
     return "WARNING [ Please try to republish the missing data or raise a GGUS ticket ]"


### PR DESCRIPTION
Change the check to return OK to <= 1%, rather than < 1%, so that the test is slightly more relaxed and so that warnings are only raised above 1% difference, rather than at 1% difference.

Resolves #4 